### PR TITLE
Remove hero temporarily

### DIFF
--- a/html/main.mustache
+++ b/html/main.mustache
@@ -1,7 +1,5 @@
 <div class="interactive-wrapper oi">
 
-	{{> hero}}
-
 	<article>
 		<div class="oi-content oi-wrap oi-content--intro oi-content--with-ml">
 			<div class="gs-container">

--- a/sass/module/content.scss
+++ b/sass/module/content.scss
@@ -41,10 +41,8 @@ $colour-content-border: $colour-neutral-2;
 }
 
 .oi-content--with-ml {
-	@include multiline(4, $colour-neutral-2, top)
 	padding-top: multiline-height(4) * 1px;
 	border-top: 0;
-
 }
 
 .oi-content__body {


### PR DESCRIPTION
We've been asked to remove the hero temporarily until we have more time to update for the new campaign branding.